### PR TITLE
Added host tagging for jumpcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ Default: `no`
 
 Whether or not to use sudo during installation.
 
+#### [`jumpcloud_add_tags`][jc-add-tags]
+Default: `no`
+
+Whether or not to add system tags to the jumpcloud system.
+Requires the ability to become root to retrieve the system key.
+Depends on jumpcloud_api_key and jumpcloud_system_tags.
+
+#### [`jumpcloud_api_key`][jc-api-key]
+Default: none
+
+API Key of a JumpCloud Administrator account authorized to add system tags.
+
+#### [`jumpcloud_system_tags`][jc-system-tags]
+Default: none
+
+List of tags to add to the system on JumpCloud.
+
 ## Example Playbook
 ----------------
 
@@ -86,6 +103,21 @@ Whether or not to use sudo during installation.
 - hosts: production
   roles:
      - { role: shrikeh.jumpcloud, jumpcloud_x_connect_key: 'abcdef012234343' }
+...
+```
+
+## Example Playbook with system tags
+----------------
+
+```YAML
+---
+- hosts: production
+  vars:
+    jumpcloud_system_tags:
+      - adminstaff
+      - common
+  roles:
+    - { role: shrikeh.jumpcloud, jumpcloud_x_connect_key: `abcdef01223434', jumpcloud_add_tags: yes, jumpcloud_use_sudo: yes }
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,5 +146,8 @@ Contact me on Twitter @[barney_hanlon][twitter]
 [jc-force-install]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L17 "Link to variable on master"
 [jc-agent-service]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L18 "Link to variable on master"
 [jc-use-sudo]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L19 "Link to variable on master"
+[jc-add-tags]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L20 "Link to variable on master"
+[jc-api-key]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L21 "Link to variable on master"
+[jc-system-tags]: https://github.com/shrikeh-ansible-roles/ansible-jumpcloud/blob/master/defaults/main.yml#L22 "Link to variable on master"
 [licence]: https://raw.githubusercontent.com/shrikeh/ansible-jumpcloud/master/LICENSE
 [twitter]: https://twitter.com/barney_hanlon "Link to my Twitter page"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,5 @@ jumpcloud_template_path: 'install.j2'
 jumpcloud_force_install: no
 jumpcloud_agent_service: jcagent
 jumpcloud_use_sudo: no
+jumpcloud_add_tags: no
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,7 @@
 - name:       Ensure jcagent is enabled and started
   become: "{{ jumpcloud_use_sudo }}"
   service: name=jcagent enabled=true state=running
+
+- name:       Add system tags to jumpcloud
+  include:    tag.yml
+  when:       jumpcloud_add_tags

--- a/tasks/tag.yml
+++ b/tasks/tag.yml
@@ -1,0 +1,22 @@
+---
+- name:     Wait for /opt/jc/jcagent.conf to exist
+  wait_for:
+    path:   /opt/jc/jcagent.conf
+
+- name:     Get systemKey from jcagent.conf
+  shell:    "cat /opt/jc/jcagent.conf | python -c 'import sys, json; print json.load(sys.stdin)[sys.argv[1]]' systemKey"
+  register: jumpcloud_system_key
+  become:   "{{ jumpcloud_use_sudo }}"
+
+- name: Use JumpCloud API to tag this system.
+  uri:
+    url:    https://console.jumpcloud.com/api/systems/{{ jumpcloud_system_key.stdout | mandatory }}
+    method: PUT
+    body:  '{ "tags" : {{ jumpcloud_system_tags | to_json }} }'
+    body_format: json
+    body_type: json
+    return_content: yes
+    HEADER_Content-Type:  "application/json"
+    HEADER_Accept:        "application/json"
+    HEADER_x-api-key:     "{{ jumpcloud_api_key | mandatory }}"
+


### PR DESCRIPTION
This feature adds the added functionality of jumpcloud tags to a system.

With the vars related to that:
jumpcloud_api_key: string
jumpcloud_add_tags: bool
jumpcloud_system_tags: list

I updated documentation as well.
