### PR TITLE
Deprecation warning - Change service state from running to started.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,4 +14,4 @@
 
 - name:       Ensure jcagent is enabled and started
   become: "{{ jumpcloud_use_sudo }}"
-  service: name=jcagent enabled=true state=running
+  service: name=jcagent enabled=true state=started


### PR DESCRIPTION
Change state from running to started.  state=running will be removed in Ansible 2.7.