### PR TITLE
Deprecation warning.  Changed from HEADERS_ to headers.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,8 @@
 - name:     Get the install script
   uri:
     url: "{{ jumpcloud_x_connect_url | mandatory }}"
-    HEADER_x-connect-key: "{{ jumpcloud_x_connect_key | mandatory }}"
+    headers:
+      x-connect-key: "{{ jumpcloud_x_connect_key | mandatory }}"
     return_content: yes
   delegate_to: 127.0.0.1
   run_once: true


### PR DESCRIPTION
Resolves the deprecation warning.
`[DEPRECATION WARNING]: Supplying headers via HEADER_* is deprecated and will be removed in a future version. Please use `headers` to supply headers for the request.
This feature will be removed in a future release. Deprecation warnings can be disabled by
 setting deprecation_warnings=False in ansible.cfg.`